### PR TITLE
HTML tag Reference에 대한 주소를 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
         * HTML Tag Reference - [http://www.w3schools.com/tags/default.asp](http://www.w3schools.com/tags/default.asp)
     *   Javascript - [http://www.codecademy.com/en/tracks/javascript](http://www.codecademy.com/en/tracks/javascript)
     *   jQuery - [http://www.codecademy.com/en/tracks/jquery](http://www.codecademy.com/en/tracks/jquery)
+        * jQuery API Documentation - [http://api.jquery.com/](http://api.jquery.com/)
     *   Make a Website - [http://www.codecademy.com/skills/make-a-website](http://www.codecademy.com/skills/make-a-website)
     *   Make a Interactive Web site - [http://www.codecademy.com/skills/make-an-interactive-website](http://www.codecademy.com/skills/make-an-interactive-website)
     *   웹개발 언어 세션 하나 선택 해서 수강 - Python / Ruby / PHP 중 하나


### PR DESCRIPTION
HTML tag Reference에 대한 주소를 추가했습니다. 저같은 경우는 최초에 HTML 배울때 저 사이트를 뻔질나게 드나들면서 tag에 붙는 attr들을 찾아봤던 기억이 나네요.
제이쿼리 API 문서 역시 같은 맥락에서 추가해보았습니다.
웹 개발을 처음 하는 분들이라면 이러한 레퍼런스를 볼 수 있는 사이트가 큰 도움이 되지 않을까 싶습니다. 사실 처음하는 사람이라면 이런 참조 문서에 어떻게 접근하는지부터가 큰 난관인 경우가 있지 않을까 싶네요.
